### PR TITLE
docs: Use absolute GitHub links between README translations

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,8 +1,8 @@
 # Obsidian - Frontmatter Date Manager
 
-[English](README.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru.md) | **Deutsch** | [日本語](README.ja.md)
+[English](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.md) | [简体中文](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.zh-CN.md) | [Русский](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.ru.md) | **Deutsch** | [日本語](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.ja.md)
 
-_Übersetzung der englischen [README](README.md). Einen Fehler entdeckt? Beiträge sind willkommen - siehe [CONTRIBUTING.md](CONTRIBUTING.md)._
+_Übersetzung der englischen [README](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.md). Einen Fehler entdeckt? Beiträge sind willkommen - siehe [CONTRIBUTING.md](CONTRIBUTING.md)._
 
 [![CI](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/SmetDenis/obsidian-frontmatter-date-manager)](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/releases/latest)

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,8 +1,8 @@
 # Obsidian - Frontmatter Date Manager
 
-[English](README.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru.md) | [Deutsch](README.de.md) | **日本語**
+[English](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.md) | [简体中文](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.zh-CN.md) | [Русский](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.ru.md) | [Deutsch](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.de.md) | **日本語**
 
-_英語版 [README](README.md) の翻訳です。誤りを見つけましたか？ コントリビューションを歓迎します - [CONTRIBUTING.md](CONTRIBUTING.md) をご覧ください。_
+_英語版 [README](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.md) の翻訳です。誤りを見つけましたか？ コントリビューションを歓迎します - [CONTRIBUTING.md](CONTRIBUTING.md) をご覧ください。_
 
 [![CI](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/SmetDenis/obsidian-frontmatter-date-manager)](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/releases/latest)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Obsidian - Frontmatter Date Manager
 
-**English** | [简体中文](README.zh-CN.md) | [Русский](README.ru.md) | [Deutsch](README.de.md) | [日本語](README.ja.md)
+**English** | [简体中文](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.zh-CN.md) | [Русский](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.ru.md) | [Deutsch](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.de.md) | [日本語](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.ja.md)
 
 [![CI](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/SmetDenis/obsidian-frontmatter-date-manager)](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/releases/latest)

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,8 +1,8 @@
 # Obsidian - Frontmatter Date Manager
 
-[English](README.md) | [简体中文](README.zh-CN.md) | **Русский** | [Deutsch](README.de.md) | [日本語](README.ja.md)
+[English](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.md) | [简体中文](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.zh-CN.md) | **Русский** | [Deutsch](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.de.md) | [日本語](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.ja.md)
 
-_Перевод английского [README](README.md). Заметили ошибку? Будем рады вкладу - см. [CONTRIBUTING.md](CONTRIBUTING.md)._
+_Перевод английского [README](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.md). Заметили ошибку? Будем рады вкладу - см. [CONTRIBUTING.md](CONTRIBUTING.md)._
 
 [![CI](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/SmetDenis/obsidian-frontmatter-date-manager)](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/releases/latest)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,8 +1,8 @@
 # Obsidian - Frontmatter Date Manager
 
-[English](README.md) | **简体中文** | [Русский](README.ru.md) | [Deutsch](README.de.md) | [日本語](README.ja.md)
+[English](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.md) | **简体中文** | [Русский](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.ru.md) | [Deutsch](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.de.md) | [日本語](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.ja.md)
 
-_本文档译自[英文 README](README.md)。发现错误？欢迎参与改进，详见 [CONTRIBUTING.md](CONTRIBUTING.md)。_
+_本文档译自[英文 README](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README.md)。发现错误？欢迎参与改进，详见 [CONTRIBUTING.md](CONTRIBUTING.md)。_
 
 [![CI](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/SmetDenis/obsidian-frontmatter-date-manager)](https://github.com/SmetDenis/obsidian-frontmatter-date-manager/releases/latest)


### PR DESCRIPTION
## What

The language switcher (line 3) in all five READMEs and the "translation of the English README" sentence in the four translated ones now link to absolute `https://github.com/SmetDenis/obsidian-frontmatter-date-manager/blob/main/README*.md` URLs instead of relative paths.

## Why

Relative links only resolve when the file is rendered inside the repository. Everywhere else the README shows up - the Obsidian community plugin page, npm-style mirrors, aggregators - they point at nothing, so a reader cannot switch language.

## Scope

Docs only, no code. Deliberately left untouched:

- the current language stays bold plain text (standard practice - it marks the page you are on);
- `CONTRIBUTING.md`, `LICENSE` and `screenshots/*.png` links stay relative (different class of link; images would additionally need `raw.githubusercontent.com`).