### PR TITLE
build(deps): Patch five Dependabot alerts in dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-frontmatter-date-manager",
-  "version": "1.2.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-frontmatter-date-manager",
-      "version": "1.2.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "^1.5.0",
@@ -750,25 +750,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -6014,9 +6028,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Five open Dependabot alerts pointed at `fast-uri` (four high, host confusion and SSRF via URL normalization) and `@humanfs/node` (symlink-following recursive copy), both reached only through the lint toolchain. Neither package is bundled into `dist/main.js`, so users of the plugin were never exposed - but the alerts were resolvable with a semver-compatible bump, so they are now closed.

The bump is deliberately targeted rather than `npm audit fix`, which wanted to pull `webdriverio` 9.27 -> 9.31 plus ten new transitive packages to fix the same two issues.

- `fast-uri` 3.1.5 -> 3.1.7 (closes GHSA-jqff-g426-hqxp, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-5jgf-p345-68v8).
- `@humanfs/node` 0.16.7 -> 0.16.8 (closes GHSA-p498-v437-472g).
- Lockfile `version` field realigned with `package.json` (1.2.1 -> 1.4.0), where it had drifted since the 1.3.0 release.

The one remaining alert, `extract-zip` (GHSA-jmr9-qjv8-65gv), is left open on purpose: no patched release exists, it is reached only by the manual `make test-e2e` run through `@wdio/utils` -> `@puppeteer/browsers`, and the only upgrade path that drops it is blocked upstream by wdio's `^2.2.0` pin.

## Type

- [ ] Bug fix
- [ ] Feature (opt-in, safe-by-default)
- [ ] Refactor / internal
- [x] Docs / tests / tooling

## Safety checklist

- [x] Frontmatter is mutated only through `processFrontMatter()`, and only configured keys are touched.
- [x] Writes happen only on a real, detected change (no unconditional or no-op writes).
- [x] Any destructive path is opt-in, defaults to safe, and gates behind a dry-run preview.

## Checklist

- [x] `make pre-commit` passes (format, lint, typecheck-e2e, test, build).
- [ ] Added or updated unit tests for any logic change.
- [ ] Updated docs where behavior changed (`README.md`, `CLAUDE.md`, `e2e/README.md`).
- [ ] Regenerated screenshots (`make screenshots`) if a captured surface changed.
- [x] Kept the `obsidian` types on the tilde pin (`~1.13.1`; verify any newer API against the current public Obsidian release) and did not disable any `obsidianmd/*` rule.